### PR TITLE
Update README for Rust 2024 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once built, make sure the resulting binary is in your PATH so you can call `git 
 
 ## Planned dependencies
 
-- Rust (edition 2021)
+- Rust (edition 2024)
 - Cargo for building and running tests
 - libgit2 bindings (via [git2-rs](https://github.com/rust-lang/git2-rs)) to manipulate Git repositories
 


### PR DESCRIPTION
## Summary
- document planned dependency on Rust 2024 edition

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869370cf7a08333b239e15065532529