### PR TITLE
Improve error message for missing git signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ $ cargo build --release
 
 Once built, make sure the resulting binary is in your PATH so you can call `git memo`.
 
+Before recording memos, configure your Git username and email so commits can be created:
+
+```
+$ git config --global user.name "Your Name"
+$ git config --global user.email "you@example.com"
+```
+
 ## Planned dependencies
 
 - Rust (edition 2024)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,13 @@ fn add_memo(category: &str, message: &str) -> Result<(), git2::Error> {
     };
 
     // Prepare author/committer signature from git config
-    let sig = repo.signature()?;
+    // Provide a clearer error if user.name or user.email are missing
+    let sig = repo.signature().map_err(|_| {
+        git2::Error::from_str(
+            "Git user.name and user.email must be set.\n\
+Run `git config --global user.name <name>` and `git config --global user.email <email>`",
+        )
+    })?;
 
     // Parent is refs/memo/<category> if exists
     let refname = format!("refs/memo/{category}");


### PR DESCRIPTION
## Summary
- show a clearer message when git user name and email are missing
- document the need to configure git user information

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68693fe2d17c83338fba0761b0eaacb3