### PR TITLE
Extend CI to run fmt, clippy and matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           profile: minimal
           override: true
+          components: clippy, rustfmt
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
       - run: cargo test --verbose


### PR DESCRIPTION
## Summary
- run the workflow on stable/beta/nightly
- add rustfmt and clippy checks

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686995edbbb483338eb335ad4b2a8eaa