### PR TITLE
Extend CI to run fmt, clippy and matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           profile: minimal
           override: true
+          components: clippy, rustfmt
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
       - run: cargo test --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,10 @@ Run `git config --global user.name <name>` and `git config --global user.email <
 
     // Parent is refs/memo/<category> if exists
     let refname = format!("refs/memo/{category}");
-    let parent = repo.refname_to_id(&refname).ok().and_then(|oid| repo.find_commit(oid).ok());
+    let parent = repo
+        .refname_to_id(&refname)
+        .ok()
+        .and_then(|oid| repo.find_commit(oid).ok());
     let parents = parent.iter().collect::<Vec<_>>();
 
     let commit_oid = repo.commit(Some(&refname), &sig, &sig, message, &tree, &parents)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,7 +16,11 @@ fn adds_memo_commit() {
     let dir = tempdir().unwrap();
 
     // init repo
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
 
     // config user
     Command::new("git")


### PR DESCRIPTION
## Summary
- run the workflow on stable/beta/nightly
- add rustfmt and clippy checks
- format source code so `cargo fmt -- --check` passes

## Testing
- `cargo test`
- `rustfmt --check src/main.rs tests/cli.rs`


------
https://chatgpt.com/codex/tasks/task_e_686995edbbb483338eb335ad4b2a8eaa