### PR TITLE
Extend CI with clippy, fmt and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           profile: minimal
           override: true
+          components: rustfmt, clippy
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
       - run: cargo test --verbose

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,10 @@ Run `git config --global user.name <name>` and `git config --global user.email <
 
     // Parent is refs/memo/<category> if exists
     let refname = format!("refs/memo/{category}");
-    let parent = repo.refname_to_id(&refname).ok().and_then(|oid| repo.find_commit(oid).ok());
+    let parent = repo
+        .refname_to_id(&refname)
+        .ok()
+        .and_then(|oid| repo.find_commit(oid).ok());
     let parents = parent.iter().collect::<Vec<_>>();
 
     let commit_oid = repo.commit(Some(&refname), &sig, &sig, message, &tree, &parents)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,7 +16,11 @@ fn adds_memo_commit() {
     let dir = tempdir().unwrap();
 
     // init repo
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
 
     // config user
     Command::new("git")
@@ -50,7 +54,11 @@ fn adds_memo_commit() {
 fn lists_memos() {
     let dir = tempdir().unwrap();
 
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
     Command::new("git")
         .args(["config", "user.name", "Test"])
         .current_dir(&dir)
@@ -82,7 +90,11 @@ fn lists_memos() {
 fn removes_memos() {
     let dir = tempdir().unwrap();
 
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
     Command::new("git")
         .args(["config", "user.name", "Test"])
         .current_dir(&dir)
@@ -117,7 +129,11 @@ fn removes_memos() {
 #[test]
 fn errors_when_missing_git_config() {
     let dir = tempdir().unwrap();
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
 
     // Use empty HOME so no global git config is found
     let empty_home = tempdir().unwrap();
@@ -134,7 +150,11 @@ fn errors_when_missing_git_config() {
 #[test]
 fn errors_on_invalid_category() {
     let dir = tempdir().unwrap();
-    Command::new("git").arg("init").current_dir(&dir).assert().success();
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
     Command::new("git")
         .args(["config", "user.name", "Test"])
         .current_dir(&dir)


### PR DESCRIPTION
## Summary
- run CI on both stable and nightly toolchains
- add `cargo fmt` and `cargo clippy` checks
- apply `cargo fmt` to code

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6869a2bb9de48333bd4842b5cfed981f