### PR TITLE
Allow memos without configured email

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ $ cargo build --release
 
 Once built, make sure the resulting binary is in your PATH so you can call `git memo`.
 
-Before recording memos, configure your Git username and email so commits can be created:
+Before recording memos, configure your Git username so commits can be created.
+Setting `user.email` is optional:
 
 ```
 $ git config --global user.name "Your Name"
-$ git config --global user.email "you@example.com"
+$ git config --global user.email "you@example.com" # optional
 ```
 
 ## Planned dependencies


### PR DESCRIPTION
## Summary
- allow `git-memo add` to succeed when `user.email` is empty
- fallback to a placeholder email and update README
- adjust error text and tests
- add regression test for adding a memo without email

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_686a0b3c2e4c833395d02aae784ae47d