### PR TITLE
feat: add JSON output option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "clap",
  "git2",
  "predicates",
+ "serde_json",
  "tempfile",
 ]
 
@@ -376,6 +377,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -620,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +650,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 git2 = "0.20"
+serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ git memo categories
 $ git memo list-categories
 
 Categories are printed in alphabetical order for easy scanning.
+For machine-readable output, pass `--json` to either command:
+
+```bash
+$ git memo list todo --json
+$ git memo categories --json
+```
 
 # edit the latest memo message
 $ git memo edit todo "updated message"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -87,6 +87,41 @@ fn lists_memos() {
 }
 
 #[test]
+fn lists_memos_json() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "first memo"])
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["list", "todo", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("first memo"))
+        .stdout(predicate::str::contains("\"oid\""));
+}
+
+#[test]
 fn lists_categories() {
     let dir = tempdir().unwrap();
 
@@ -124,6 +159,47 @@ fn lists_categories() {
         .success()
         .stdout(predicate::str::contains("todo"))
         .stdout(predicate::str::contains("idea"));
+}
+
+#[test]
+fn lists_categories_json() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "first memo"])
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "idea", "another"])
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["categories", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("todo"))
+        .stdout(predicate::str::contains("idea"))
+        .stdout(predicate::str::starts_with("["));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow listing memos or categories in JSON via `--json`
- update tests to cover new flag
- document JSON output in README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_686a0e7609288333bad5f754b2fe4002