### PR TITLE
feat: read memo message from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ By storing memos in Git, agents gain a stable history that survives checkouts or
 ```
 # record a memo under refs/memo/todo
 $ git memo add todo "Finish writing README"
+# read a multi-line message from stdin
+$ cat msg.txt | git memo add todo -
+
+When the message is `-`, `git memo` reads the memo text from standard input.
 
 # show the log of todo memos
 $ git log refs/memo/todo

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -51,6 +51,42 @@ fn adds_memo_commit() {
 }
 
 #[test]
+fn adds_memo_from_stdin() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "-"])
+        .write_stdin("line one\nline two\n")
+        .assert()
+        .success();
+
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=%B", "refs/memo/todo"])
+        .current_dir(&dir)
+        .output()
+        .unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("line one"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("line two"));
+}
+
+#[test]
 fn lists_memos() {
     let dir = tempdir().unwrap();
 


### PR DESCRIPTION
## Summary
- allow `git memo add` to take `-` as the message
- read multiline memo text from stdin when using `-`
- document stdin support in the README
- test reading message from stdin

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_686a1e36e0708333a1911e725073d2b7