### PR TITLE
feat: share repo discovery helper

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,5 @@
+use git2::Repository;
+
+pub fn open_repo() -> Result<Repository, git2::Error> {
+    Repository::discover(".")
+}


### PR DESCRIPTION
## Summary
- add `open_repo()` helper in new commands module
- replace repeated `Repository::discover(".")` calls with `open_repo`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_686a25774ec0833389322b154e01ffe7