### PR TITLE
Add rustdoc to CLI and commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{CommandFactory, Parser, Subcommand};
 use git_memo::{add_memo, archive_category, edit_memo, list_categories, list_memos, remove_memos};
 
+/// Top-level command line interface for the git-memo application.
 #[derive(Parser)]
 #[command(name = "git-memo", about = "Record memos using Git")]
 struct Cli {


### PR DESCRIPTION
## Summary
- document `Cli` struct
- add rustdoc for public command functions with parameters and usage example

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_686a47e06d548333b059f503cdf261a7