### PR TITLE
Add helper for commit signatures

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -15,7 +15,7 @@ pub fn open_repo() -> Result<Repository, git2::Error> {
 ///
 /// `user.name` must be set while `user.email` is optional. If no email is
 /// configured, "none" is used.
-pub fn make_signature(repo: &Repository) -> Result<Signature, git2::Error> {
+pub fn make_signature(repo: &Repository) -> Result<Signature<'_>, git2::Error> {
     let config = repo.config()?;
     let name = config.get_string("user.name").map_err(|_| {
         git2::Error::from_str(


### PR DESCRIPTION
## Summary
- factor out signature creation from git config into `make_signature`
- use `make_signature` in `add_memo` and `edit_memo`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686a77a2ef6883339a5da412b5806c72