### PR TITLE
Add grep command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -228,3 +228,49 @@ pub fn archive_category(category: &str) -> Result<(), git2::Error> {
     }
     Ok(())
 }
+
+/// Search all memo commits for a pattern.
+///
+/// This runs `git log --grep=<pattern> refs/memo/*` and prints the matching
+/// commit messages to stdout.
+pub fn grep_memos(pattern: &str) -> Result<(), git2::Error> {
+    use std::path::Path;
+    use std::process::Command;
+
+    let repo = open_repo()?;
+    let workdir = repo.workdir().unwrap_or_else(|| Path::new("."));
+
+    let refs = repo.references_glob("refs/memo/*")?;
+    let mut args = vec![
+        "log".to_string(),
+        "--format=%s".into(),
+        "--grep".into(),
+        pattern.to_string(),
+    ];
+    for reference in refs {
+        let reference = reference?;
+        if let Some(name) = reference.name() {
+            args.push(name.to_string());
+        }
+    }
+
+    if args.len() == 4 {
+        println!("No memos found");
+        return Ok(());
+    }
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(workdir)
+        .output()
+        .map_err(|e| git2::Error::from_str(&format!("Failed to run git log: {e}")))?;
+
+    if !output.status.success() {
+        return Err(git2::Error::from_str(&String::from_utf8_lossy(
+            &output.stderr,
+        )));
+    }
+
+    print!("{}", String::from_utf8_lossy(&output.stdout));
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod commands;
 
 pub use commands::{
-    add_memo, archive_category, edit_memo, list_categories, list_memos, remove_memos,
+    add_memo, archive_category, edit_memo, grep_memos, list_categories, list_memos, remove_memos,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{CommandFactory, Parser, Subcommand};
-use git_memo::{add_memo, archive_category, edit_memo, list_categories, list_memos, remove_memos};
+use git_memo::{
+    add_memo, archive_category, edit_memo, grep_memos, list_categories, list_memos, remove_memos,
+};
 
 /// Top-level command line interface for the git-memo application.
 #[derive(Parser)]
@@ -52,6 +54,11 @@ enum Commands {
         /// Category to archive
         category: String,
     },
+    /// Search memos matching a pattern
+    Grep {
+        /// Pattern to search for
+        pattern: String,
+    },
 }
 
 /// Application entry point.
@@ -85,5 +92,6 @@ fn handle_command(cmd: Commands) -> Result<(), git2::Error> {
         Commands::Categories { json } => list_categories(json),
         Commands::Edit { category, message } => edit_memo(&category, &message),
         Commands::Archive { category } => archive_category(&category),
+        Commands::Grep { pattern } => grep_memos(&pattern),
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -443,3 +443,43 @@ fn errors_on_invalid_category() {
         .failure()
         .stderr(predicate::str::contains("not valid"));
 }
+
+#[test]
+fn greps_memos() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "hello world"])
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "another note"])
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["grep", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"))
+        .stdout(predicate::str::contains("another note").not());
+}


### PR DESCRIPTION
## Summary
- extend CLI with `grep` subcommand
- implement `grep_memos` to search memo commits
- expose new function in library
- test pattern matching for `grep`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_686a7e70e44883338365bcb111a391e5