### PR TITLE
feat: add version info to help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,13 @@ use git_memo::{
 
 /// Top-level command line interface for the git-memo application.
 #[derive(Parser)]
-#[command(name = "git-memo", about = "Record memos using Git")]
+#[command(
+    name = "git-memo",
+    about = "Record memos using Git",
+    version,
+    propagate_version = true,
+    help_template = "{name} {version}\n{about-with-newline}{usage-heading} {usage}\n\n{all-args}{after-help}"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,7 +8,8 @@ fn shows_help() {
     cmd.arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("add"));
+        .stdout(predicate::str::contains("add"))
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Clap version annotation and help template to show version in `--help`
- verify version string in help output

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_686feb5e22b88333b1f5cb11a868e5ec