### PR TITLE
feat: list archived memo categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ $ git memo archive todo
 
 The archive command renames `refs/memo/todo` to `refs/archive/todo` so
 the category can be hidden without deleting its history.
+
+# list archived categories
+$ git memo archive-categories
+$ git memo archive-categories --json
 ```
 
 Each memo is an empty commit so repository history is unaffected. Categories live under their own refs and can be removed or archived independently.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -244,6 +244,35 @@ pub fn list_categories(json_output: bool) -> Result<(), git2::Error> {
     Ok(())
 }
 
+/// Display all archived memo categories.
+///
+/// When `json_output` is true, the category names are printed as a JSON array.
+///
+/// # Parameters
+/// - `json_output`: Enable JSON output when set to `true`.
+pub fn list_archive_categories(json_output: bool) -> Result<(), git2::Error> {
+    let repo = open_repo()?;
+    let refs = repo.references_glob("refs/archive/*")?;
+    let mut categories = BTreeSet::new();
+    for reference in refs {
+        let reference = reference?;
+        if let Some(cat) = reference
+            .name()
+            .and_then(|name| name.strip_prefix("refs/archive/"))
+        {
+            categories.insert(cat.to_string());
+        }
+    }
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&categories).unwrap());
+    } else {
+        for cat in categories {
+            println!("{cat}");
+        }
+    }
+    Ok(())
+}
+
 /// Amend the latest memo commit for `category` with a new message.
 ///
 /// # Parameters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod commands;
 
 pub use commands::{
-    add_memo, archive_category, edit_memo, grep_memos, list_categories, list_memos, push_memos,
-    remove_memos,
+    add_memo, archive_category, edit_memo, grep_memos, list_archive_categories, list_categories,
+    list_memos, push_memos, remove_memos,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{CommandFactory, Parser, Subcommand};
 use git_memo::{
-    add_memo, archive_category, edit_memo, grep_memos, list_categories, list_memos, push_memos,
-    remove_memos,
+    add_memo, archive_category, edit_memo, grep_memos, list_archive_categories, list_categories,
+    list_memos, push_memos, remove_memos,
 };
 
 /// Top-level command line interface for the git-memo application.
@@ -39,6 +39,13 @@ enum Commands {
     /// List all memo categories
     #[command(alias = "list-categories")]
     Categories {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// List archived memo categories
+    #[command(alias = "list-archive-categories")]
+    ArchiveCategories {
         /// Output in JSON format
         #[arg(long)]
         json: bool,
@@ -96,6 +103,7 @@ fn handle_command(cmd: Commands) -> Result<(), git2::Error> {
         Commands::List { category, json } => list_memos(&category, json),
         Commands::Remove { category } => remove_memos(&category),
         Commands::Categories { json } => list_categories(json),
+        Commands::ArchiveCategories { json } => list_archive_categories(json),
         Commands::Edit { category, message } => edit_memo(&category, &message),
         Commands::Archive { category } => archive_category(&category),
         Commands::Grep { pattern } => grep_memos(&pattern),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -323,6 +323,91 @@ fn archives_category() {
 }
 
 #[test]
+fn lists_archive_categories() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "first memo"])
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "idea", "another"])
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["archive", "todo"])
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .arg("archive-categories")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("todo"))
+        .stdout(predicate::str::contains("idea").not());
+}
+
+#[test]
+fn lists_archive_categories_json() {
+    let dir = tempdir().unwrap();
+
+    Command::new("git")
+        .arg("init")
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["add", "todo", "first memo"])
+        .assert()
+        .success();
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["archive", "todo"])
+        .assert()
+        .success();
+
+    let mut cmd = Command::cargo_bin("git-memo").unwrap();
+    cmd.current_dir(&dir)
+        .args(["archive-categories", "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("todo"))
+        .stdout(predicate::str::starts_with("["));
+}
+
+#[test]
 fn removes_memos() {
     let dir = tempdir().unwrap();
 


### PR DESCRIPTION
## Summary
- implement `list_archive_categories` in `src/commands.rs`
- expose new `archive-categories` CLI subcommand
- cover the new command with tests
- document archive category listing in the README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_686feb5fc664833394f66579e4ea5b44