### PR TITLE
Add --repo option to select repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ $ git memo grep hello
 hello world
 ```
 
+Pass `--repo <PATH>` to work with a different repository from any location.
+
 ## Organizing categories
 
 Categories are simple names under `refs/memo/`. Keep them short (e.g. `todo`, `idea`, `bug`) so that Git ref names remain valid. You can create as many categories as needed and list or remove them independently.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use git_memo::{
     add_memo, archive_category, edit_memo, grep_memos, list_archive_categories, list_categories,
     list_memos, push_memos, remove_memos,
 };
+use std::path::PathBuf;
 
 /// Top-level command line interface for the git-memo application.
 #[derive(Parser)]
@@ -14,6 +15,9 @@ use git_memo::{
     help_template = "{name} {version}\n{about-with-newline}{usage-heading} {usage}\n\n{all-args}{after-help}"
 )]
 struct Cli {
+    /// Path to the Git repository
+    #[arg(long, global = true, value_name = "PATH")]
+    repo: Option<PathBuf>,
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -90,10 +94,10 @@ fn main() {
 
 /// Parse command line arguments and dispatch the requested subcommand.
 fn run() -> Result<(), git2::Error> {
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
 
-    match cli.command {
-        Some(cmd) => handle_command(cmd),
+    match cli.command.take() {
+        Some(cmd) => handle_command(cmd, cli),
         None => {
             // Default to showing help if no command is given
             Cli::command().print_help().unwrap();
@@ -103,16 +107,16 @@ fn run() -> Result<(), git2::Error> {
 }
 
 /// Execute an individual CLI command.
-fn handle_command(cmd: Commands) -> Result<(), git2::Error> {
+fn handle_command(cmd: Commands, cli: Cli) -> Result<(), git2::Error> {
     match cmd {
-        Commands::Add { category, message } => add_memo(&category, &message),
-        Commands::List { category, json } => list_memos(&category, json),
-        Commands::Remove { category } => remove_memos(&category),
-        Commands::Categories { json } => list_categories(json),
-        Commands::ArchiveCategories { json } => list_archive_categories(json),
-        Commands::Edit { category, message } => edit_memo(&category, &message),
-        Commands::Archive { category } => archive_category(&category),
-        Commands::Grep { pattern } => grep_memos(&pattern),
-        Commands::Push { remote } => push_memos(&remote),
+        Commands::Add { category, message } => add_memo(cli.repo.clone(), &category, &message),
+        Commands::List { category, json } => list_memos(cli.repo.clone(), &category, json),
+        Commands::Remove { category } => remove_memos(cli.repo.clone(), &category),
+        Commands::Categories { json } => list_categories(cli.repo.clone(), json),
+        Commands::ArchiveCategories { json } => list_archive_categories(cli.repo.clone(), json),
+        Commands::Edit { category, message } => edit_memo(cli.repo.clone(), &category, &message),
+        Commands::Archive { category } => archive_category(cli.repo.clone(), &category),
+        Commands::Grep { pattern } => grep_memos(cli.repo.clone(), &pattern),
+        Commands::Push { remote } => push_memos(cli.repo.clone(), &remote),
     }
 }


### PR DESCRIPTION
## Summary
- add `--repo <PATH>` global argument
- open repositories from optional path and validate `.git`
- pass the repo path to all command handlers
- support specifying relative or absolute paths in CLI tests
- document `--repo` usage in README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_687cc0df0a1c8333b49d40209ba64d5b